### PR TITLE
Update creators_rss_reader.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ Enabling features in this plugin will create user accounts and post content to y
 
 ## Support
 Please use the [tech support portal](http://get.creators.com/contact/tech) on GET for support and feature requests for this plugin.
+
+## CHANGES
+I made several changes, including filtering for duplicate post titles instead of post names (which are slugs), because the slug can be changed by some themes via permalink settings. Also changed filter_post_like() function to check titles.
+
+I added to settings the ability to choose categories and tags for each author, and/or default categories and tags that will be used if not set for individual authors. With these changes, categories and tags are created along with the post. Categories, especially can be very useful in determining where and how the posts will be displayed on the website. 
+
+In order to make the above work, changes were made to these functions: create_post(), filter_post_like(), register_settings(); and new functions were created: display_setting_cats_text($args), display_setting_tags_text($args), display_setting_default_cats_text(), display_setting_default_tags_text(). Additions were made to the $default_options array as well.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Enabling features in this plugin will create user accounts and post content to y
 Please use the [tech support portal](http://get.creators.com/contact/tech) on GET for support and feature requests for this plugin.
 
 ## CHANGES
-I made several changes, including filtering for duplicate post titles instead of post names (which are slugs), because the slug can be changed by some themes via permalink settings. Also changed filter_post_like() function to check titles.
-
 I added to settings the ability to choose categories and tags for each author, and/or default categories and tags that will be used if not set for individual authors. With these changes, categories and tags are created along with the post. Categories, especially can be very useful in determining where and how the posts will be displayed on the website. 
 
 In order to make the above work, changes were made to these functions: create_post(), filter_post_like(), register_settings(); and new functions were created: display_setting_cats_text($args), display_setting_tags_text($args), display_setting_default_cats_text(), display_setting_default_tags_text(). Additions were made to the $default_options array as well.

--- a/creators_rss_reader/creators_rss_reader.php
+++ b/creators_rss_reader/creators_rss_reader.php
@@ -171,15 +171,15 @@ class CreatorsRSSReader
 
 		// if nothing in an Author's category or tag, use mydefault
 		// in either case, explode by commas to create arrays
-		if (empty($postcat[$file_code])) {
-			$postcats = explode(',', $mydefault_cat);
+		if (empty($postcat[$file_code]) || is_null($postcat[$file_code])) {
+			$postcats = array_map('trim', explode(',', $mydefault_cat));
 		} else {
-			$postcats = explode(',', $postcat[$file_code]);
+			$postcats = array_map('trim', explode(',', $postcat[$file_code]));
 		}
-		if (empty($posttag[$file_code])) {
-			$posttags = explode(',', $mydefault_tag);
+		if (empty($posttag[$file_code]) || is_null($postcat[$file_code])) {
+			$posttags = array_map('trim', explode(',', $mydefault_tag));
 		} else {
-			$posttags = explode(',', $posttag[$file_code]);
+			$posttags = array_map('trim', explode(',', $posttag[$file_code]));
 		}
 
 		$post = array();
@@ -196,9 +196,8 @@ class CreatorsRSSReader
 
         add_filter( 'posts_where', array('CreatorsRSSReader', 'filter_post_like'), 10, 2 );
         
-	// using post_title instead of post_name (slug), as slug is changed by some themes via permalink settings, also changed filter_post_like()
         $args = array(
-		'cr_search_name' => $post['post_title']
+            'cr_search_name' => substr($post['post_name'], 0, strpos($post['post_name'], '-'))
         );
         
         $wp_query = new WP_Query($args);
@@ -479,11 +478,11 @@ class CreatorsRSSReader
 
         if($search_term = $wp_query->get('cr_search_name'))
         {
-            // add single quotes to search term
-            $search_term = ' \'' . $search_term . '\'';
+            $search_term = $wpdb->esc_like($search_term);
+            $search_term = ' \'' . $search_term . '-%\'';
             var_dump($search_term);
-			// changed from post_name (slug) to post_title and 'LIKE' to '='
-            $where .= ' AND ' . $wpdb->posts . '.post_title = '.$search_term;
+            $where .= ' AND ' . $wpdb->posts . '.post_name LIKE '.$search_term;
+
         }
         
         return $where;

--- a/creators_rss_reader/creators_rss_reader.php
+++ b/creators_rss_reader/creators_rss_reader.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Creators RSS Reader
+ * Plugin Name: Creators RSS Reader-HT2
  * Plugin URI: https://github.com/creatorssyn/creators_rss_reader
  * Description: A plugin to interface Creators content directly into your WordPress CMS
  * Version: 1.0.0
@@ -29,15 +29,19 @@ class CreatorsRSSReader
         'creators_feed_reader_post_name_pattern'=>'%t', 
         'creators_feed_reader_user_ids'=>array(),
         'creators_feed_reader_last_run'=>0,
-        'creators_feed_reader_features'=>array()
+        'creators_feed_reader_features'=>array(),
+	'creators_feed_reader_tags'=>array(),
+	'creators_feed_reader_cats'=>array(),
+	'creators_feed_reader_default_cats'=>'',
+	'creators_feed_reader_default_tags'=>''
     );
     
     protected static $instance;
     
-    function init() 
+   public static function init() 
     {
         is_null(self::$instance) AND self::$instance = new self;
-        
+
         // Actions
         add_action('parse_rss_feed', array('CreatorsRSSReader', 'parse_rss_feed'));
         add_action('admin_menu', array('CreatorsRSSReader', 'add_menu_option'));
@@ -50,7 +54,7 @@ class CreatorsRSSReader
     /**
      * Activate the plugin
      */
-    function activate()
+   public static function activate()
     {
         if (!current_user_can('activate_plugins'))
             return;
@@ -68,7 +72,7 @@ class CreatorsRSSReader
     /**
      * Deactivate the plugin
      */
-    function deactivate()
+   public static function deactivate()
     {
         if (!current_user_can('activate_plugins'))
             return;
@@ -81,7 +85,7 @@ class CreatorsRSSReader
      * Uninstall the plugin
      * Should this delete all users and posts? 
      */
-    function uninstall()
+   public static function uninstall()
     {
         if (!current_user_can('activate_plugins'))
             return;
@@ -100,7 +104,7 @@ class CreatorsRSSReader
      * Read the Creators RSS Feed and post content to the site
      * @return boolean TRUE if feed was read, FALSE if feed cannot be read or hasn't been updated
      */
-    function parse_rss_feed()
+   public static function parse_rss_feed()
     {
         if(!function_exists('simplexml_load_file'))
         {
@@ -113,8 +117,8 @@ class CreatorsRSSReader
         $url = 'http://get.creators.com/feed/'.get_option('creators_feed_reader_api_key').'.rss';
         $xml = simplexml_load_file($url);
         
-        //var_dump($xml->channel);
-        
+        var_dump($xml->channel);
+        /* TESTING: Comment out to let it run */
         if(strtotime($xml->channel->lastBuildDate) <= get_option('creators_feed_reader_last_run'))
         {
             echo "Feed is stale, bye!";
@@ -128,7 +132,7 @@ class CreatorsRSSReader
             preg_match('/([a-z0-9]{2,4})@/', $item->author, $m);
             if(isset($m[1]) && self::$instance->should_post_feature($m[1]))
             {
-                self::$instance->create_post($item);
+		self::$instance->create_post($item);
             }
         }
         
@@ -141,7 +145,7 @@ class CreatorsRSSReader
      * @param string $filecode Creators feature file code
      * @return boolean 
      */ 
-    private function should_post_feature($filecode)
+    private static function should_post_feature($filecode)
     {
         $users = get_option('creators_feed_reader_features');
         return isset($users[$filecode]) && $users[$filecode] == 'on';
@@ -149,40 +153,65 @@ class CreatorsRSSReader
     
     /**
      * Create a post from a feature release
-     * 
      * @param object $item SimpleXML item object
      * @return mixed ID of new post, or WP_Error on error
+     * HT: added category, tags, and changed 'cr_search_name' 
      */
-    private function create_post($item)
+    private static function create_post($item)
     {
-        $post = array();
-        $post['post_content'] = (string)$item->description;
-        $post['post_name'] = self::$instance->parse_post_name($item);
-        $post['post_title'] = (string)substr($item->title[0], 0, strrpos($item->title[0], ' by '));
-        $post['post_status'] = get_option('creators_feed_reader_auto_publish')? 'publish': 'draft';
-        $post['post_author'] = self::$instance->get_user_id($item->author);
-        $post['post_date'] = date('Y-m-d H:i:s', strtotime($item->pubDate));
+		// get author code, comes before '@'
+		$author_code = $item->author;
+		$arrauth = explode("@", $author_code, 2);
+		$file_code = $arrauth[0];
+		// get categories and tags
+		$mydefault_cat = get_option('creators_feed_reader_default_cats');
+		$mydefault_tag = get_option('creators_feed_reader_default_tags');
+		$postcat = get_option('creators_feed_reader_cats');
+		$posttag = get_option('creators_feed_reader_tags');
+
+		// if nothing in an Author's category or tag, use mydefault
+		// in either case, explode by commas to create arrays
+		if (empty($postcat[$file_code])) {
+			$postcats = explode(',', $mydefault_cat);
+		} else {
+			$postcats = explode(',', $postcat[$file_code]);
+		}
+		if (empty($posttag[$file_code])) {
+			$posttags = explode(',', $mydefault_tag);
+		} else {
+			$posttags = explode(',', $posttag[$file_code]);
+		}
+
+		$post = array();
+		$post['post_content'] = (string)$item->description;
+		$post['post_name'] = self::$instance->parse_post_name($item);
+		$post['post_title'] = (string)substr($item->title[0], 0, strrpos($item->title[0], ' by '));
+		$post['post_status'] = get_option('creators_feed_reader_auto_publish')? 'publish': 'draft';
+		$post['post_author'] = self::$instance->get_user_id($item->author);
+		$post['post_date'] = date('Y-m-d H:i:s', strtotime($item->pubDate));
+		$post['post_category'] = $postcats;
+		$post['tags_input'] = $posttags;
         
         var_dump($post);
+
+        add_filter( 'posts_where', array('CreatorsRSSReader', 'filter_post_like'), 10, 2 );
         
-        add_filter('posts_where', array('CreatorsRSSReader', 'filter_post_like'), 10, 2);
-        
+	// using post_title instead of post_name (slug), as slug is changed by some themes via permalink settings, also changed filter_post_like()
         $args = array(
-            'cr_search_name' => substr($post['post_name'], 0, strpos($post['post_name'], '-'))
+		'cr_search_name' => $post['post_title']
         );
         
         $wp_query = new WP_Query($args);
+
         remove_filter( 'posts_where', array('CreatorsRSSReader', 'filter_post_like'), 10, 2 );
-        
-        if(!$wp_query->have_posts())
-        {
-            return wp_insert_post($post);
-        }
-        else
-        {
-            return FALSE;
-        }
-    }
+
+		if(!$wp_query->have_posts()) {
+			return wp_insert_post($post);
+		} else {
+			return FALSE;
+		}
+
+	}
     
     /**
      * Create a user account for a Creators feature
@@ -190,7 +219,7 @@ class CreatorsRSSReader
      * @param string $filecode Creators feature file code
      * @return boolean
      */
-    private function create_user($filecode)
+    private static function create_user($filecode)
     {
         try
         {
@@ -249,7 +278,7 @@ class CreatorsRSSReader
      * @param string $author_string The author attribute of an RSS item
      * @return mixed User ID, or NULL if a user doesn't exist
      */
-    private function get_user_id($author_string)
+    private static function get_user_id($author_string)
     {
         preg_match('/([a-z0-9]+)@/', $author_string, $m);
 
@@ -269,7 +298,7 @@ class CreatorsRSSReader
      * @param object $item SimpleXML item object
      * @return string Post URL
      */
-    private function parse_post_name($item)
+    private static function parse_post_name($item)
     {
         $slug = get_option('creators_feed_reader_post_name_pattern');
         preg_match('|/([0-9]+)|', $item->guid, $matches);
@@ -286,20 +315,24 @@ class CreatorsRSSReader
      * @param string $title Feature title
      * @return string Username
      */
-    private function make_username($title)
+    private static function make_username($title)
     {
         return sanitize_user(strtolower(str_replace(' ', '', $title)), TRUE);
     }
     
     /**
-     * Settings functions
+     * Settings functions: added tags, categories, and defaults for both
      */
-    function register_settings()
+   public static function register_settings()
     {
         register_setting('creators_rss', 'creators_feed_reader_api_key');
         register_setting('creators_rss', 'creators_feed_reader_auto_publish');
         register_setting('creators_rss', 'creators_feed_reader_post_name_pattern');
         register_setting('creators_rss', 'creators_feed_reader_features');
+	register_setting('creators_rss', 'creators_feed_reader_tags');
+	register_setting('creators_rss', 'creators_feed_reader_cats');
+	register_setting('creators_rss', 'creators_feed_reader_default_cats');
+	register_setting('creators_rss', 'creators_feed_reader_default_tags');
         
         add_settings_section('creators_rss_main', 'Main Settings', array('CreatorsRSSReader', 'display_main_text'), 'creators_rss');
         add_settings_field('creators_feed_reader_api_key', 'Your API Key', array('CreatorsRSSReader', 'display_setting_api_key'), 'creators_rss', 'creators_rss_main');
@@ -316,64 +349,91 @@ class CreatorsRSSReader
             $features = NULL;
         }
 
-        
         if($features !== NULL && count($features) > 0)
         {
             add_settings_section('creators_rss_features', 'Your Features', array('CreatorsRSSReader', 'display_features_text'), 'creators_rss');
+		add_settings_field('creators_feed_reader_default_cats', 'Default categories for all features (ID #s, separated by commas)', array('CreatorsRSSReader', 'display_setting_default_cats_text'), 'creators_rss', 'creators_rss_features');
+		add_settings_field('creators_feed_reader_default_tags', 'Default tags for all features (separated by commas)', array('CreatorsRSSReader', 'display_setting_default_tags_text'), 'creators_rss', 'creators_rss_features');
             foreach($features as $f)
             {
                 add_settings_field('creators_feed_reader_features['.$f['file_code'].']', $f['title'], array('CreatorsRSSReader', 'display_setting_author_checkbox'), 'creators_rss', 'creators_rss_features', array($f['file_code']));
+		add_settings_field('creators_feed_reader_cats['.$f['file_code'].']', '<div style="margin: -20px 0 0 15px;">Categories (ID #s, separated by commas)</div>', array('CreatorsRSSReader', 'display_setting_cats_text'), 'creators_rss', 'creators_rss_features', array($f['file_code']));
+		add_settings_field('creators_feed_reader_tags['.$f['file_code'].']', '<div style="margin: -20px 0 0 15px;">Tags (Separated by commas)</div>', array('CreatorsRSSReader', 'display_setting_tags_text'), 'creators_rss', 'creators_rss_features', array($f['file_code']));
             }
         }
     }
     
-    function add_menu_option()
+   public static function add_menu_option()
     {
         $page_hook = add_submenu_page('options-general.php', 'Creators RSS Feed', 'Creators RSS Feed', 'manage_options', 'creators-rss-feeds-options', array('CreatorsRSSReader', 'display_options_page'));
         add_action('load-'.$page_hook, array('CreatorsRSSReader', 'settings_load_hook'));
     }
     
-    function display_main_text()
+   public static function display_main_text()
     {
         echo '<p>General feed reader settings</p>';
     }
     
-    function display_features_text()
+   public static function display_features_text()
     {
-        echo '<p>Enable features you want to post to your site below</p>';
+        echo '<p>Enable features you want to post to your site below, along with any tags and/or category IDs you want to assign to posts by these artists, separated by commas.</p>';
     }
     
-    function display_setting_name_pattern()
+   public static function display_setting_cats_text($args)
+    {
+        $file_code = $args[0];
+	$authorcats = get_option('creators_feed_reader_cats');
+        echo "<div style='margin-top: -20px'><input id='creators_feed_reader_cats[{$file_code}]' name='creators_feed_reader_cats[{$file_code}]' size='40' type='text' value=".json_encode($authorcats[$file_code])." /></div>";
+    }
+
+   public static function display_setting_tags_text($args)
+    {
+        $file_code = $args[0];
+	$authortags = get_option('creators_feed_reader_tags');
+        echo "<div style='margin-top: -20px'><input id='creators_feed_reader_tags[{$file_code}]' name='creators_feed_reader_tags[{$file_code}]' size='40' type='text' value=".json_encode($authortags[$file_code])." /></div>";
+    }
+
+   public static function display_setting_default_cats_text()
+    {
+       $option = get_option('creators_feed_reader_default_cats');
+        echo "<input id='creators_feed_reader_default_cats' name='creators_feed_reader_default_cats' size='40' type='text' value='{$option}' />";
+    }
+
+   public static function display_setting_default_tags_text()
+    {
+       $option = get_option('creators_feed_reader_default_tags');
+        echo "<input id='creators_feed_reader_default_tags' name='creators_feed_reader_default_tags' size='40' type='text' value='{$option}' />";
+    }
+
+   public static function display_setting_name_pattern()
     {
         $option = get_option('creators_feed_reader_post_name_pattern');
         echo "<input id='creators_feed_reader_post_name_pattern' name='creators_feed_reader_post_name_pattern' size='40' type='text' value='{$option}' />";
     }
     
-    function display_setting_auto_publish()
+   public static function display_setting_auto_publish()
     {
         $option = get_option('creators_feed_reader_auto_publish');
         echo "<input id='creators_feed_reader_auto_publish' type='checkbox' name='creators_feed_reader_auto_publish' ".($option?"checked='checked'":"")." />";
     }
     
-    function display_setting_api_key()
+   public static function display_setting_api_key()
     {
         $option = get_option('creators_feed_reader_api_key');
         echo "<input id='creators_feed_reader_api_key' name='creators_feed_reader_api_key' size='40' type='text' value='{$option}' />";
     }
     
-    function display_setting_author_checkbox($args)
+   public static function display_setting_author_checkbox($args)
     {
         $file_code = $args[0];
-        $authors = get_option('creators_feed_reader_features');
-        
+	$authors = get_option('creators_feed_reader_features');
         $checked = FALSE;
         if(isset($authors[$file_code]) && $authors[$file_code] == 'on')
             $checked = TRUE;
-        
         echo "<input id='creators_feed_reader_features[{$file_code}]' type='checkbox' name='creators_feed_reader_features[{$file_code}]' ".($checked?"checked='checked'":"")." />";
     }
     
-    function display_options_page()
+   public static function display_options_page()
     {
         if ( !current_user_can( 'manage_options' ) )  {
             wp_die( __( 'You do not have sufficient permissions to access this page.' ) );
@@ -389,7 +449,7 @@ class CreatorsRSSReader
         echo '</div>';
     }
     
-    function settings_load_hook()
+   public static function settings_load_hook()
     {
         if(isset($_GET['settings-updated']) && $_GET['settings-updated'])
         {
@@ -406,26 +466,29 @@ class CreatorsRSSReader
         }
     }
     
-    function plugin_action_links($links)
+   public static function plugin_action_links($links)
     {
         $links[] = '<a href="'. esc_url( get_admin_url(null, 'options-general.php?page=creators-rss-feeds-options') ) .'">Settings</a>';
         return $links;
     }
     
-    function filter_post_like($where, &$wp_query)
+	// removed & from before $wp_query, was giving PHP 'reference' warning
+   public static function filter_post_like($where, $wp_query)
     {
         global $wpdb;
 
         if($search_term = $wp_query->get('cr_search_name'))
         {
-            $search_term = $wpdb->esc_like($search_term);
-            $search_term = ' \'' . $search_term . '-%\'';
+            // add single quotes to search term
+            $search_term = ' \'' . $search_term . '\'';
             var_dump($search_term);
-            $where .= ' AND ' . $wpdb->posts . '.post_name LIKE '.$search_term;
+			// changed from post_name (slug) to post_title and 'LIKE' to '='
+            $where .= ' AND ' . $wpdb->posts . '.post_title = '.$search_term;
         }
         
         return $where;
     }
+
 }
 
 /* Set hooks */

--- a/creators_rss_reader/creators_rss_reader.php
+++ b/creators_rss_reader/creators_rss_reader.php
@@ -118,7 +118,7 @@ class CreatorsRSSReader
         $xml = simplexml_load_file($url);
         
         var_dump($xml->channel);
-        /* TESTING: Comment out to let it run */
+
         if(strtotime($xml->channel->lastBuildDate) <= get_option('creators_feed_reader_last_run'))
         {
             echo "Feed is stale, bye!";


### PR DESCRIPTION
CHANGES MADE:

I made several changes, including filtering for duplicate post titles instead of post names (which are slugs), because the slug can be changed by some themes via permalink settings. Also changed filter_post_like() function to check titles.

I added to Settings (Creators RSS Feed Options) the ability to choose categories and tags for each author, and/or default categories and tags that will be used if not set for individual authors. With these changes, categories and tags are created along with each post. Categories, especially, can be very useful in determining where and how the posts will be displayed on the website.

In order to make the above work, changes were made to these functions: 
create_post(), filter_post_like(), register_settings(). 

New functions were created: 
display_setting_cats_text($args), display_setting_tags_text($args), display_setting_default_cats_text(), display_setting_default_tags_text(). 

Additions were made to the $default_options array as well.